### PR TITLE
Remove comma

### DIFF
--- a/presets.json
+++ b/presets.json
@@ -1,5 +1,5 @@
 {
   "Pretty Purple": "https://github.com/GradienceTeam/Community/raw/main/presets/pretty-purple.json",
   "Synthwave": "https://github.com/GradienceTeam/Community/raw/main/presets/synthwave.json",
-  "Fedora 37 Night": "https://github.com/GradienceTeam/Community/raw/main/presets/fedora-37-night.json",
+  "Fedora 37 Night": "https://github.com/GradienceTeam/Community/raw/main/presets/fedora-37-night.json"
 }


### PR DESCRIPTION
JSON is very strict with its syntax, so that comma makes an error:
```
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 5 column 1 (char 301)
```