### PR TITLE
Remove slug-case from names of several presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,114 @@ In your Pull Request, add your Preset in the `presets` folder and add a link to 
 ## Preset stored somewhere else
 
 In your Pull Request, add a link to your Preset in `presets.json`
+
+# Preset example
+```json
+{
+    "name": "Preset Name", // The name should be written as shown, in PascalCase, but with spaces between words
+    "variables": {
+        "accent_color": "#78aeed",
+        "accent_bg_color": "#3584e4",
+        "accent_fg_color": "#ffffff",
+        "destructive_color": "#ff7b63",
+        "destructive_bg_color": "#c01c28",
+        "destructive_fg_color": "#ffffff",
+        "success_color": "#8ff0a4",
+        "success_bg_color": "#26a269",
+        "success_fg_color": "#ffffff",
+        "warning_color": "#f8e45c",
+        "warning_bg_color": "#cd9309",
+        "warning_fg_color": "rgba(0, 0, 0, 0.8)",
+        "error_color": "#ff7b63",
+        "error_bg_color": "#c01c28",
+        "error_fg_color": "#ffffff",
+        "window_bg_color": "#242424",
+        "window_fg_color": "#ffffff",
+        "view_bg_color": "#1e1e1e",
+        "view_fg_color": "#ffffff",
+        "headerbar_bg_color": "#303030",
+        "headerbar_fg_color": "#ffffff",
+        "headerbar_border_color": "#ffffff",
+        "headerbar_backdrop_color": "@window_bg_color",
+        "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
+        "card_bg_color": "rgba(255, 255, 255, 0.08)",
+        "card_fg_color": "#ffffff",
+        "card_shade_color": "rgba(0, 0, 0, 0.36)",
+        "dialog_bg_color": "#383838",
+        "dialog_fg_color": "#ffffff",
+        "popover_bg_color": "#383838",
+        "popover_fg_color": "#ffffff",
+        "shade_color": "rgba(0,0,0,0.36)",
+        "scrollbar_outline_color": "rgba(0,0,0,0.5)"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    }
+}
+```

--- a/presets/builder-dark.json
+++ b/presets/builder-dark.json
@@ -1,5 +1,5 @@
 {
-    "name": "builder-dark",
+    "name": "Builder Dark",
     "variables": {
         "accent_color": "#41606f",
         "accent_bg_color": "#4186a8",

--- a/presets/builder-light.json
+++ b/presets/builder-light.json
@@ -1,5 +1,5 @@
 {
-    "name": "builder-light",
+    "name": "Builder Light",
     "variables": {
         "accent_color": "#75aac1",
         "accent_bg_color": "#0077aa",

--- a/presets/classic-dark.json
+++ b/presets/classic-dark.json
@@ -1,5 +1,5 @@
 {
-    "name": "classic-dark",
+    "name": "Classic Dark",
     "variables": {
         "accent_color": "#4f6989",
         "accent_bg_color": "#3584e4",

--- a/presets/classic-light.json
+++ b/presets/classic-light.json
@@ -1,5 +1,5 @@
 {
-    "name": "classic-light",
+    "name": "Classic Light",
     "variables": {
         "accent_color": "#81abdf",
         "accent_bg_color": "#3584e4",

--- a/presets/cobalt-dark.json
+++ b/presets/cobalt-dark.json
@@ -1,5 +1,5 @@
 {
-    "name": "cobalt-dark",
+    "name": "Cobalt Dark",
     "variables": {
         "accent_color": "#1963a3",
         "accent_bg_color": "#0088ff",

--- a/presets/cobalt-light.json
+++ b/presets/cobalt-light.json
@@ -1,5 +1,5 @@
 {
-    "name": "cobalt-light",
+    "name": "Cobalt Light",
     "variables": {
         "accent_color": "#7eb8e8",
         "accent_bg_color": "#30a0ff",

--- a/presets/kate-dark.json
+++ b/presets/kate-dark.json
@@ -1,5 +1,5 @@
 {
-    "name": "kate-dark",
+    "name": "Kate Dark",
     "variables": {
         "accent_color": "#3b525e",
         "accent_bg_color": "#2d5c76",

--- a/presets/kate-light.json
+++ b/presets/kate-light.json
@@ -1,5 +1,5 @@
 {
-    "name": "kate-light",
+    "name": "Kate Light",
     "variables": {
         "accent_color": "#91c0db",
         "accent_bg_color": "#43ace8",

--- a/presets/oblivion.json
+++ b/presets/oblivion.json
@@ -1,5 +1,5 @@
 {
-    "name": "oblivion",
+    "name": "Oblivion",
     "variables": {
         "accent_color": "#696d6b",
         "accent_bg_color": "#888a85",

--- a/presets/peninsula-dark.json
+++ b/presets/peninsula-dark.json
@@ -1,1 +1,107 @@
-{"name": "peninsula-dark", "variables": {"accent_color": "#405a7d", "accent_bg_color": "#3169b0", "accent_fg_color": "#ffffff", "destructive_color": "#ff7b63", "destructive_bg_color": "#c01c28", "destructive_fg_color": "#ffffff", "success_color": "#8ff0a4", "success_bg_color": "#26a269", "success_fg_color": "#ffffff", "warning_color": "#f8e45c", "warning_bg_color": "#cd9309", "warning_fg_color": "rgba(0, 0, 0, 0.8)", "error_color": "#ff7b63", "error_bg_color": "#c01c28", "error_fg_color": "#ffffff", "window_bg_color": "#292a30", "window_fg_color": "#dfdfe0", "view_bg_color": "#4a4b51", "view_fg_color": "#dfdfe0", "headerbar_bg_color": "#38393f", "headerbar_fg_color": "#dfdfe0", "headerbar_border_color": "#ffffff", "headerbar_backdrop_color": "@window_bg_color", "headerbar_shade_color": "rgba(0, 0, 0, 0.36)", "card_bg_color": "#3a3b41", "card_fg_color": "#dfdfe0", "card_shade_color": "rgba(0, 0, 0, 0.36)", "dialog_bg_color": "#292a30", "dialog_fg_color": "#dfdfe0", "popover_bg_color": "#38393f", "popover_fg_color": "#dfdfe0", "shade_color": "#383838", "scrollbar_outline_color": "rgba(0, 0, 0, 0.5)"}, "palette": {"blue_": {"1": "#99c1f1", "2": "#62a0ea", "3": "#3584e4", "4": "#1c71d8", "5": "#1a5fb4"}, "green_": {"1": "#8ff0a4", "2": "#57e389", "3": "#33d17a", "4": "#2ec27e", "5": "#26a269"}, "yellow_": {"1": "#f9f06b", "2": "#f8e45c", "3": "#f6d32d", "4": "#f5c211", "5": "#e5a50a"}, "orange_": {"1": "#ffbe6f", "2": "#ffa348", "3": "#ff7800", "4": "#e66100", "5": "#c64600"}, "red_": {"1": "#f66151", "2": "#ed333b", "3": "#e01b24", "4": "#c01c28", "5": "#a51d2d"}, "purple_": {"1": "#dc8add", "2": "#c061cb", "3": "#9141ac", "4": "#813d9c", "5": "#613583"}, "brown_": {"1": "#cdab8f", "2": "#b5835a", "3": "#986a44", "4": "#865e3c", "5": "#63452c"}, "light_": {"1": "#ffffff", "2": "#f6f5f4", "3": "#deddda", "4": "#c0bfbc", "5": "#9a9996"}, "dark_": {"1": "#77767b", "2": "#5e5c64", "3": "#3d3846", "4": "#241f31", "5": "#000000"}}, "custom_css": {"gtk4": "", "gtk3": ""}}
+{
+    "name": "Peninsula Dark",
+    "variables": {
+        "accent_color": "#405a7d",
+        "accent_bg_color": "#3169b0",
+        "accent_fg_color": "#ffffff",
+        "destructive_color": "#ff7b63",
+        "destructive_bg_color": "#c01c28",
+        "destructive_fg_color": "#ffffff",
+        "success_color": "#8ff0a4",
+        "success_bg_color": "#26a269",
+        "success_fg_color": "#ffffff",
+        "warning_color": "#f8e45c",
+        "warning_bg_color": "#cd9309",
+        "warning_fg_color": "rgba(0, 0, 0, 0.8)",
+        "error_color": "#ff7b63",
+        "error_bg_color": "#c01c28",
+        "error_fg_color": "#ffffff",
+        "window_bg_color": "#292a30",
+        "window_fg_color": "#dfdfe0",
+        "view_bg_color": "#4a4b51",
+        "view_fg_color": "#dfdfe0",
+        "headerbar_bg_color": "#38393f",
+        "headerbar_fg_color": "#dfdfe0",
+        "headerbar_border_color": "#ffffff",
+        "headerbar_backdrop_color": "@window_bg_color",
+        "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
+        "card_bg_color": "#3a3b41",
+        "card_fg_color": "#dfdfe0",
+        "card_shade_color": "rgba(0, 0, 0, 0.36)",
+        "dialog_bg_color": "#292a30",
+        "dialog_fg_color": "#dfdfe0",
+        "popover_bg_color": "#38393f",
+        "popover_fg_color": "#dfdfe0",
+        "shade_color": "#383838",
+        "scrollbar_outline_color": "rgba(0, 0, 0, 0.5)"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    }
+}

--- a/presets/peninsula-light.json
+++ b/presets/peninsula-light.json
@@ -1,5 +1,5 @@
 {
-    "name": "peninsula-light",
+    "name": "Peninsula Light",
     "variables": {
         "accent_color": "#75ace7",
         "accent_bg_color": "#007bff",

--- a/presets/solarized-dark.json
+++ b/presets/solarized-dark.json
@@ -1,5 +1,5 @@
 {
-    "name": "solarized-dark",
+    "name": "Solarized Dark",
     "variables": {
         "accent_color": "#426068",
         "accent_bg_color": "#657b83",

--- a/presets/solarized-light.json
+++ b/presets/solarized-light.json
@@ -1,5 +1,5 @@
 {
-    "name": "solarized-light",
+    "name": "Solarized Light",
     "variables": {
         "accent_color": "#b9bcb4",
         "accent_bg_color": "#93a1a1",

--- a/presets/tango.json
+++ b/presets/tango.json
@@ -1,5 +1,5 @@
 {
-    "name": "tango",
+    "name": "Tango",
     "variables": {
         "accent_color": "#8db1dc",
         "accent_bg_color": "#3584e4",

--- a/presets/yaru-dark.json
+++ b/presets/yaru-dark.json
@@ -1,5 +1,5 @@
 {
-    "name": "Yaru-dark",
+    "name": "Yaru Dark",
     "variables": {
         "accent_color": "@orange_5",
         "accent_bg_color": "@orange_5",


### PR DESCRIPTION
Change slug-case names to PascalCase, so they look correct in presets window: 
![Screenshot from 2022-09-01 14-38-05](https://user-images.githubusercontent.com/73042332/187915494-a8d6e64c-9708-47de-b77b-10f8828f3c21.png)
