### PR TITLE
Catppuccin Frappe - fix dropdown hovered item color

### DIFF
--- a/presets/catppuccin-frappe.json
+++ b/presets/catppuccin-frappe.json
@@ -3,7 +3,7 @@
     "variables": {
         "accent_color": "rgb(140, 170, 238)",
         "accent_bg_color": "rgb(140, 170, 238)",
-        "accent_fg_color": "rgb(198, 208, 245)",
+        "accent_fg_color": "rgb(255, 255, 255)",
         "destructive_color": "rgb(231, 130, 132)",
         "destructive_bg_color": "rgb(231, 130, 132)",
         "destructive_fg_color": "rgb(48, 52, 70)",

--- a/presets/catppuccin-frappe.json
+++ b/presets/catppuccin-frappe.json
@@ -3,7 +3,7 @@
     "variables": {
         "accent_color": "rgb(140, 170, 238)",
         "accent_bg_color": "rgb(140, 170, 238)",
-        "accent_fg_color": "rgb(48, 52, 70)",
+        "accent_fg_color": "rgb(198, 208, 245)",
         "destructive_color": "rgb(231, 130, 132)",
         "destructive_bg_color": "rgb(231, 130, 132)",
         "destructive_fg_color": "rgb(48, 52, 70)",


### PR DESCRIPTION
Hovering the mouse over an item causes it to become invisible in some dropdowns, e.g. in the settings (Preferences → General) of Gnome Terminal. This is caused by `accent_fg_color` being set to the same color as the dropdown's background.

I fixed this by changing the `accent_fg_color` color.

It's possible that destructive/success/warning/error colors need to be changed in a similar fashion, but I've found no evidence of that yet.