### PR TITLE
Add Nord Dark preset

### DIFF
--- a/nord-dark.json
+++ b/nord-dark.json
@@ -1,0 +1,107 @@
+{
+    "name": "Nord Dark",
+    "variables": {
+        "accent_color": "rgb(136,192,208)",
+        "accent_bg_color": "rgb(136,192,208)",
+        "accent_fg_color": "rgb(46,52,64)",
+        "destructive_color": "rgb(208,135,112)",
+        "destructive_bg_color": "rgb(208,135,112)",
+        "destructive_fg_color": "rgb(46,52,64)",
+        "success_color": "rgb(163,190,140)",
+        "success_bg_color": "rgb(163,190,140)",
+        "success_fg_color": "rgb(46,52,64)",
+        "warning_color": "rgb(235,203,139)",
+        "warning_bg_color": "rgb(235,203,139)",
+        "warning_fg_color": "rgb(46,52,64)",
+        "error_color": "rgb(191,97,106)",
+        "error_bg_color": "rgb(191,97,106)",
+        "error_fg_color": "rgb(46,52,64)",
+        "window_bg_color": "rgb(46,52,64)",
+        "window_fg_color": "rgb(236,239,244)",
+        "view_bg_color": "rgb(59,66,82)",
+        "view_fg_color": "rgb(236,239,244)",
+        "headerbar_bg_color": "rgb(59,66,82)",
+        "headerbar_fg_color": "rgb(236,239,244)",
+        "headerbar_border_color": "rgb(59,66,82)",
+        "headerbar_backdrop_color": "@window_bg_color",
+        "headerbar_shade_color": "rgb(59,66,82)",
+        "card_bg_color": "rgb(46,52,64)",
+        "card_fg_color": "rgb(236,239,244)",
+        "card_shade_color": "rgb(59,66,82)",
+        "dialog_bg_color": "rgb(67,76,94)",
+        "dialog_fg_color": "rgb(236,239,244)",
+        "popover_bg_color": "rgb(67,76,94)",
+        "popover_fg_color": "rgb(236,239,244)",
+        "shade_color": "rgb(59,66,82)",
+        "scrollbar_outline_color": "rgb(229,233,240)"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    }
+}


### PR DESCRIPTION
# New Preset: Nord Dark

As this is a variant of an existing preset, I'm leaving it on draft status until there's a system in place for distinguishing different versions apart.

## Description

An arctic, north-bluish color palette.

## Palette
  
[Nord](https://www.nordtheme.com/)
  
## Screenshots (optional)

<!-- Will be used in showcase -->

## Wallpaper

![1586853771_daniel-leone-v7datklzzaw-unsplash-modded](https://user-images.githubusercontent.com/104225819/190545012-7aa6e3c6-0b7f-4fe7-a85c-6dce0480cb0d.jpg)

# Checklist 

Before submitting the PR, I checked:

- [x] I've only modified one preset
- [ ] I've added the URL to my raw preset in `presets.json`
- [x] I've checked the format of each json files I modified
- [ ] (optional) I've added screenshots
- [x] The preset name is following preset naming guidelines.

## Publication 

- [x] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
