### PR TITLE
Add custom zorin os dark theme preset

### DIFF
--- a/curated/Zorin-Dark-Custom.json
+++ b/curated/Zorin-Dark-Custom.json
@@ -1,0 +1,108 @@
+{
+    "name": "Zorin Dark Custom",
+    "variables": {
+        "accent_color": "#bde6fb",
+        "accent_bg_color": "#354249",
+        "accent_fg_color": "#bde6fb",
+        "destructive_color": "#bf616a",
+        "destructive_bg_color": "#bf616a",
+        "destructive_fg_color": "#bde6fb",
+        "success_color": "#a3be8c",
+        "success_bg_color": "#171d20",
+        "success_fg_color": "#bde6fb",
+        "warning_color": "#c3674a",
+        "warning_bg_color": "#171d20",
+        "warning_fg_color": "#bde6fb",
+        "error_color": "#b84f59",
+        "error_bg_color": "#171d20",
+        "error_fg_color": "#bde6fb",
+        "window_bg_color": "#171d20",
+        "window_fg_color": "#bde6fb",
+        "view_bg_color": "#171d20",
+        "view_fg_color": "#bde6fb",
+        "headerbar_bg_color": "#1e2529",
+        "headerbar_fg_color": "#bde6fb",
+        "headerbar_border_color": "#bde6fb",
+        "headerbar_shade_color": "rgba(0,0,0,0.36)",
+        "card_bg_color": "#1e2529",
+        "card_fg_color": "#bde6fb",
+        "card_shade_color": "rgba(0,0,0,0.36)",
+        "dialog_bg_color": "#171d20",
+        "dialog_fg_color": "#bde6fb",
+        "popover_bg_color": "#171d20",
+        "popover_fg_color": "#bde6fb",
+        "shade_color": "#171d20",
+        "scrollbar_outline_color": "rgba(0, 0, 0, 0.5)",
+        "headerbar_backdrop_color": "#1a2022"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#fff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    },
+    "plugins": {}
+}


### PR DESCRIPTION
this is my attempt at recreating the zorin os dark theme

Signed-off-by: georgewoodall82 <47471634+georgewoodall82@users.noreply.github.com>

# New Preset: Zorin Dark Custom

<!-- comments -->

## An alright recreation of the zorin os dark theme

<!-- will be used in the preset list -->

## Palette
  
<!-- a color palette used for this preset -->

- [x] None
  
## Screenshots (optional)

<!-- Will be used in showcase -->
![Screenshot](https://user-images.githubusercontent.com/47471634/200956179-0ebdf298-30e4-4108-bf91-a9a6521e418f.png)

## Wallpaper

<!-- When we are taking screenshots for adding in the preset list on the website, we can use your background. Maybe add a related background here or nothing if it's not important so we are going to use the default background -->

# Checklist 

Before submitting the PR, I checked:

- [x] I've only modified one preset
- [ ] I've added the URL to my raw preset in `presets.json`
- [x] I've checked the format of each json files I modified
- [x] (optional) I've added screenshots
- [x] The preset name is following preset naming guidelines.

## Publication 

- [x] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
