### PR TITLE
Add Matcha Sea theme

### DIFF
--- a/curated/matcha-sea.json
+++ b/curated/matcha-sea.json
@@ -1,0 +1,108 @@
+{
+    "name": "Matcha Sea",
+    "variables": {
+        "accent_color": "#279780",
+        "accent_bg_color": "#2eb398",
+        "accent_fg_color": "#ffffff",
+        "destructive_color": "#d53e3e",
+        "destructive_bg_color": "#db5b5b",
+        "destructive_fg_color": "#ffffff",
+        "success_color": "#279780",
+        "success_bg_color": "#2eb398",
+        "success_fg_color": "#ffffff",
+        "warning_color": "#f06213",
+        "warning_bg_color": "#F27835",
+        "warning_fg_color": "#ffffff",
+        "error_color": "#fb1f15",
+        "error_bg_color": "#FC4138",
+        "error_fg_color": "#ffffff",
+        "window_bg_color": "#f7f7f7",
+        "window_fg_color": "#273134",
+        "view_bg_color": "#ffffff",
+        "view_fg_color": "#303d41",
+        "headerbar_bg_color": "#1b2224",
+        "headerbar_fg_color": "#c6cdcb",
+        "headerbar_border_color": "#121718",
+        "headerbar_backdrop_color": "#1b2224",
+        "headerbar_shade_color": "rgba(0, 0, 0, 0.07)",
+        "card_bg_color": "#ffffff",
+        "card_fg_color": "#273134",
+        "card_shade_color": "rgba(0, 0, 0, 0.07)",
+        "dialog_bg_color": "#f7f7f7",
+        "dialog_fg_color": "#273134",
+        "popover_bg_color": "#ffffff",
+        "popover_fg_color": "#303d41",
+        "shade_color": "rgba(0, 0, 0, 0.35)",
+        "scrollbar_outline_color": "#ffffff"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "windowcontrols image {\n    background-color: transparent;\n}\nwindowcontrols image:hover {\n    background-color: alpha(@headerbar_fg_color, 0.16);\n}\nwindowcontrols image:active {\n    background-color: alpha(@headerbar_fg_color, 0.10);\n}\nheaderbar windowcontrols button.close image {\n    background-color: #cc575d;\n    color: @headerbar_bg_color;\n}\nheaderbar windowcontrols button.close image:hover {\n    background-color: #d7787d;\n}\nheaderbar windowcontrols button.close image:active {\n    background-color: #be3841;\n}\nswitch slider {\n    background-color: #f6f6f6;\n}\nswitch {\n    background-color: #a9a9a9;\n}\nswitch:checked {\n    background-color: @accent_bg_color;\n}\ncheckbutton check:checked {\n    color: #363636;\n    background-color:@accent_bg_color;\n}\nscale highlight {\n    background-color: @accent_color;\n}\nscale slider {\n    background-color: @accent_color;\n}\nlist row.activatable:selected {\n    color: @accent_fg_color;\n    background-color: @accent_bg_color;\n}\nwindow {\n    border-radius: 5px;\n}",
+        "gtk3": ""
+    },
+    "plugins": {}
+}


### PR DESCRIPTION
# New Preset: Matcha Sea

The main variant of the Matcha GTK color scheme.
It's a very widely used theme, specially on Manjaro where it was previously pre-installed as it has a green accent color.
Indeed, it's the theme I've used for this last year, so I wanted to make an Adwaita version as there are no other presets with a main green color that matches Manjaro correctly. Now I just share it here in case it's useful.
The Matcha Sea theme also has a light and a dark version, but this one isn't either of them but the `Matcha-sea` standard version, with a dark header bar but a light content theme.

## Description

Light theme with dark header and green accent color, based on Matcha GTK.

## Palette
  
<!-- a color palette used for this preset -->

- [X] None
  
## Screenshots (optional)

<!-- Will be used in showcase -->
![Captura desde 2022-11-16 02-31-14](https://user-images.githubusercontent.com/6679900/202061590-ff080b8d-8339-4fe0-9a01-717cb1eb19a0.png)

## Wallpaper

<!-- When we are taking screenshots for adding in the preset list on the website, we can use your background. Maybe add a related background here or nothing if it's not important so we are going to use the default background -->
None

# Checklist 

Before submitting the PR, I checked:

- [X] I've only modified one preset
- [ ] I've added the URL to my raw preset in `presets.json`
- [X] I've checked the format of each json files I modified
- [X] (optional) I've added screenshots
- [X] The preset name is following preset naming guidelines.

## Publication 

- [X] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
