### PR TITLE
Add Apprentice theme

### DIFF
--- a/curated/apprentice.json
+++ b/curated/apprentice.json
@@ -1,0 +1,106 @@
+{
+    "name": "apprentice",
+    "variables": {
+        "accent_color": "rgb(166, 170, 241)",
+        "accent_bg_color": "rgb(39, 67, 199)",
+        "accent_fg_color": "rgb(219, 219, 219)",
+        "destructive_color": "rgb(220, 121, 116)",
+        "destructive_bg_color": "rgb(180, 60, 41)",
+        "destructive_fg_color": "rgb(219, 219, 219)",
+        "success_color": "rgb(87, 230, 144)",
+        "success_bg_color": "rgb(0, 194, 0)",
+        "success_fg_color": "rgb(219, 219, 219)",
+        "warning_color": "rgb(236, 225, 0)",
+        "warning_bg_color": "rgb(199, 196, 0)",
+        "warning_fg_color": "rgba(0, 0, 0, 0.8)",
+        "error_color": "rgb(220, 121, 116)",
+        "error_bg_color": "rgb(180, 60, 41)",
+        "error_fg_color": "rgb(219, 219, 219)",
+        "window_bg_color": "rgb(20, 25, 30)",
+        "window_fg_color": "rgb(219, 219, 219)",
+        "view_bg_color": "rgb(20, 25, 30)",
+        "view_fg_color": "rgb(219, 219, 219)",
+        "headerbar_bg_color": "rgb(20, 25, 30)",
+        "headerbar_fg_color": "rgb(219, 219, 219)",
+        "headerbar_border_color": "rgb(219, 219, 219)",
+        "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
+        "card_bg_color": "rgba(255, 255, 255, 0.08)",
+        "card_fg_color": "rgb(219, 219, 219)",
+        "card_shade_color": "rgba(0, 0, 0, 0.36)",
+        "dialog_bg_color": "rgb(20, 25, 31)",
+        "dialog_fg_color": "rgb(219, 219, 219)",
+        "popover_bg_color": "rgb(20, 25, 30)",
+        "popover_fg_color": "rgb(219, 219, 219)",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
+        "scrollbar_outline_color": "rgba(0, 0, 0, 0.5)"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#fff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000"
+        }
+    },
+    "custom_css": {
+        "gtk4": ""
+    },
+    "plugins": {}
+}

--- a/curated/apprentice.json
+++ b/curated/apprentice.json
@@ -1,5 +1,5 @@
 {
-    "name": "apprentice",
+    "name": "Apprentice",
     "variables": {
         "accent_color": "rgb(166, 170, 241)",
         "accent_bg_color": "rgb(39, 67, 199)",


### PR DESCRIPTION
Signed-off-by: Asutosh Variar <96536388+asutoshvariar@users.noreply.github.com>

# New Preset: Apprentice

<!-- comments -->

## Description

The Apprentice theme made by https://github.com/romainl for use with Gradience.

## Palette
  
https://github.com/asutoshvariar/Apprentice/blob/main/apprentice.conf
  
## Screenshots (optional)

![image](https://user-images.githubusercontent.com/96536388/204125067-02c3be11-7c33-4685-b56e-27fcaf646000.png)

## Wallpaper

![image](https://github.com/asutoshvariar/mac-dotfiles/blob/main/wallpaper.jpg?raw=true)

# Checklist 

Before submitting the PR, I checked:

- [x] I've only modified one preset
- [ ] I've added the URL to my raw preset in `presets.json`
- [x] I've checked the format of each json files I modified
- [x] (optional) I've added screenshots
- [x] The preset name is following preset naming guidelines.

## Publication 

- [x] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
