### PR TITLE
Add Breeze Light and Breeze Dark

### DIFF
--- a/curated/breeze-dark.json
+++ b/curated/breeze-dark.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#fcfcfc",
         "popover_bg_color": "#1b1e20",
         "popover_fg_color": "#fcfcfc",
-        "shade_color": "rgba(255, 255, 255, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
         "scrollbar_outline_color": "rgba(0, 0, 0, 0.5)"
     },
     "palette": {

--- a/curated/breeze-dark.json
+++ b/curated/breeze-dark.json
@@ -1,0 +1,108 @@
+{
+    "name": "Breeze Dark",
+    "variables": {
+        "accent_color": "#3daee9",
+        "accent_bg_color": "#3daee9",
+        "accent_fg_color": "#ffffff",
+        "destructive_color": "#da4453",
+        "destructive_bg_color": "#da4453",
+        "destructive_fg_color": "#ffffff",
+        "success_color": "#27ae60",
+        "success_bg_color": "#27ae60",
+        "success_fg_color": "#ffffff",
+        "warning_color": "#f67400",
+        "warning_bg_color": "#f67400",
+        "warning_fg_color": "#ffffff",
+        "error_color": "#da4453",
+        "error_bg_color": "#da4453",
+        "error_fg_color": "#ffffff",
+        "window_bg_color": "#2a2e32",
+        "window_fg_color": "#fcfcfc",
+        "view_bg_color": "#1b1e20",
+        "view_fg_color": "#fcfcfc",
+        "headerbar_bg_color": "#31363b",
+        "headerbar_fg_color": "#fcfcfc",
+        "headerbar_border_color": "#fcfcfc",
+        "headerbar_backdrop_color": "#2a2e32",
+        "headerbar_shade_color": "rgba(255, 255, 255, 0.09)",
+        "card_bg_color": "#1b1e20",
+        "card_fg_color": "#fcfcfc",
+        "card_shade_color": "rgba(255, 255, 255, 0.09)",
+        "dialog_bg_color": "#2a2e32",
+        "dialog_fg_color": "#fcfcfc",
+        "popover_bg_color": "#1b1e20",
+        "popover_fg_color": "#fcfcfc",
+        "shade_color": "rgba(255, 255, 255, 0.09)",
+        "scrollbar_outline_color": "rgba(0, 0, 0, 0.5)"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    },
+    "plugins": {}
+}

--- a/curated/breeze-light.json
+++ b/curated/breeze-light.json
@@ -1,0 +1,108 @@
+{
+    "name": "Breeze Light",
+    "variables": {
+        "accent_color": "#3daee9",
+        "accent_bg_color": "#3daee9",
+        "accent_fg_color": "#ffffff",
+        "destructive_color": "#da4453",
+        "destructive_bg_color": "#da4453",
+        "destructive_fg_color": "#ffffff",
+        "success_color": "#27ae60",
+        "success_bg_color": "#27ae60",
+        "success_fg_color": "#ffffff",
+        "warning_color": "#f67400",
+        "warning_bg_color": "#f67400",
+        "warning_fg_color": "#ffffff",
+        "error_color": "#da4453",
+        "error_bg_color": "#da4453",
+        "error_fg_color": "#ffffff",
+        "window_bg_color": "#eff0f1",
+        "window_fg_color": "#232629",
+        "view_bg_color": "#ffffff",
+        "view_fg_color": "#232629",
+        "headerbar_bg_color": "#dee0e2",
+        "headerbar_fg_color": "#232629",
+        "headerbar_border_color": "#232629",
+        "headerbar_backdrop_color": "#eff0f1",
+        "headerbar_shade_color": "rgba(0, 0, 0, 0.09)",
+        "card_bg_color": "#ffffff",
+        "card_fg_color": "#232629",
+        "card_shade_color": "rgba(0, 0, 0, 0.09)",
+        "dialog_bg_color": "#eff0f1",
+        "dialog_fg_color": "#232629",
+        "popover_bg_color": "#ffffff",
+        "popover_fg_color": "#232629",
+        "shade_color": "rgba(0, 0, 0, 0.09)",
+        "scrollbar_outline_color": "#ffffff"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    },
+    "plugins": {}
+}


### PR DESCRIPTION
# New Preset: Breeze Light and Breeze Dark

<!-- comments -->

## Description

The default light and dark Breeze colour schemes, directly ported to Gradience unofficially. The original KDE colour schemes are by the KDE Visual Design Group.

## Palette
  
<!-- a color palette used for this preset -->

- [x] None
  
## Screenshots (optional)

<!-- Will be used in showcase -->

![image](https://user-images.githubusercontent.com/11057934/227750460-944666c7-e789-4289-a47f-500279bcdf17.png)
![image](https://user-images.githubusercontent.com/11057934/227750463-d2dd589d-688e-46b4-844a-6e474f239a03.png)

## Wallpaper

<!-- When we are taking screenshots for adding in the preset list on the website, we can use your background. Maybe add a related background here or nothing if it's not important so we are going to use the default background -->

https://invent.kde.org/plasma/breeze/-/tree/master/wallpapers/Next/contents

# Checklist 

Before submitting the PR, I checked:

- [ ] I've only modified one preset
- [ ] I've added the URL to my raw preset in `presets.json`
- [x] I've checked the format of each json files I modified
- [x] (optional) I've added screenshots
- [x] The preset name is following preset naming guidelines.

## Publication 

- [x] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
