### PR TITLE
Add Feren OS 2020 palettes

### DIFF
--- a/curated/feren-os-2020.json
+++ b/curated/feren-os-2020.json
@@ -1,0 +1,108 @@
+{
+    "name": "Feren OS (2020)",
+    "variables": {
+        "accent_color": "#006aff",
+        "accent_bg_color": "#006aff",
+        "accent_fg_color": "#ffffff",
+        "destructive_color": "#dc293b",
+        "destructive_bg_color": "#dc293b",
+        "destructive_fg_color": "#ffffff",
+        "success_color": "#169c39",
+        "success_bg_color": "#169c39",
+        "success_fg_color": "#ffffff",
+        "warning_color": "#e36b1a",
+        "warning_bg_color": "#e36b1a",
+        "warning_fg_color": "#ffffff",
+        "error_color": "#dc293b",
+        "error_bg_color": "#dc293b",
+        "error_fg_color": "#ffffff",
+        "window_bg_color": "#dcdcdc",
+        "window_fg_color": "#000000",
+        "view_bg_color": "#f1f1f1",
+        "view_fg_color": "#000000",
+        "headerbar_bg_color": "#dcdcdc",
+        "headerbar_fg_color": "#000000",
+        "headerbar_border_color": "#000000",
+        "headerbar_backdrop_color": "#dcdcdc",
+        "headerbar_shade_color": "rgba(0, 0, 0, 0.09)",
+        "card_bg_color": "#f1f1f1",
+        "card_fg_color": "#000000",
+        "card_shade_color": "rgba(0, 0, 0, 0.09)",
+        "dialog_bg_color": "#dcdcdc",
+        "dialog_fg_color": "#000000",
+        "popover_bg_color": "#f1f1f1",
+        "popover_fg_color": "#000000",
+        "shade_color": "rgba(0, 0, 0, 0.09)",
+        "scrollbar_outline_color": "#ffffff"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    },
+    "plugins": {}
+}

--- a/curated/feren-os-dark-2020.json
+++ b/curated/feren-os-dark-2020.json
@@ -1,0 +1,108 @@
+{
+    "name": "Feren OS Dark (2020)",
+    "variables": {
+        "accent_color": "#006aff",
+        "accent_bg_color": "#006aff",
+        "accent_fg_color": "#ffffff",
+        "destructive_color": "#cf2737",
+        "destructive_bg_color": "#cf2737",
+        "destructive_fg_color": "#ffffff",
+        "success_color": "#169137",
+        "success_bg_color": "#169137",
+        "success_fg_color": "#ffffff",
+        "warning_color": "#e36b1a",
+        "warning_bg_color": "#e36b1a",
+        "warning_fg_color": "#ffffff",
+        "error_color": "#cf2737",
+        "error_bg_color": "#cf2737",
+        "error_fg_color": "#ffffff",
+        "window_bg_color": "#222222",
+        "window_fg_color": "#ffffff",
+        "view_bg_color": "#323232",
+        "view_fg_color": "#ffffff",
+        "headerbar_bg_color": "#222222",
+        "headerbar_fg_color": "#ffffff",
+        "headerbar_border_color": "#000000",
+        "headerbar_backdrop_color": "#222222",
+        "headerbar_shade_color": "rgba(0, 0, 0, 0.09)",
+        "card_bg_color": "#323232",
+        "card_fg_color": "#ffffff",
+        "card_shade_color": "rgba(0, 0, 0, 0.09)",
+        "dialog_bg_color": "#222222",
+        "dialog_fg_color": "#ffffff",
+        "popover_bg_color": "#323232",
+        "popover_fg_color": "#ffffff",
+        "shade_color": "rgba(0, 0, 0, 0.09)",
+        "scrollbar_outline_color": "rgba(0, 0, 0, 0.5)"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    },
+    "plugins": {}
+}


### PR DESCRIPTION
# New Preset: Feren OS (2020) and Feren OS (2020) Dark

<!-- comments -->

## Description

Feren OS's light and dark colour palettes, as of the 2020 Theme Redesign, officially ported to Gradience. The original colour palette was made by @dominichayesferen (me).

## Palette
  
<!-- a color palette used for this preset -->

- [x] None
  
## Screenshots (optional)

<!-- Will be used in showcase -->

![image](https://user-images.githubusercontent.com/11057934/227750590-ec6effa6-d576-4d1b-a042-dbbc8fd8b9d3.png)
![image](https://user-images.githubusercontent.com/11057934/227750600-77f51e8b-9030-4365-bd45-b6833e0517bc.png)

## Wallpaper

<!-- When we are taking screenshots for adding in the preset list on the website, we can use your background. Maybe add a related background here or nothing if it's not important so we are going to use the default background -->

![4483x2985](https://user-images.githubusercontent.com/11057934/227750613-42dfa8b0-fc20-425d-8468-b59f8d5ce1eb.jpg)
![4483x2985](https://user-images.githubusercontent.com/11057934/227750618-756fafba-d0f8-45fd-bd84-bed064dde1c4.jpg)

# Checklist 

Before submitting the PR, I checked:

- [ ] I've only modified one preset
- [ ] I've added the URL to my raw preset in `presets.json`
- [x] I've checked the format of each json files I modified
- [x] (optional) I've added screenshots
- [x] The preset name is following preset naming guidelines.

## Publication 

- [x] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
