### PR TITLE
Fix @shade_color on Zorin OS 16 palettes

### DIFF
--- a/curated/zorin-os-16-blue-dark.json
+++ b/curated/zorin-os-16-blue-dark.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#bde6fb",
         "popover_bg_color": "#171d20",
         "popover_fg_color": "#bde6fb",
-        "shade_color": "rgba(189, 230, 251, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
         "scrollbar_outline_color": "rgba(23, 29, 32, 0.5)"
     },
     "palette": {

--- a/curated/zorin-os-16-blue.json
+++ b/curated/zorin-os-16-blue.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#123354",
         "popover_bg_color": "#ffffff",
         "popover_fg_color": "#123354",
-        "shade_color": "rgba(18, 51, 84, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.07)",
         "scrollbar_outline_color": "#ffffff"
     },
     "palette": {

--- a/curated/zorin-os-16-green-dark.json
+++ b/curated/zorin-os-16-green-dark.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#bbf1dd",
         "popover_bg_color": "#151c19",
         "popover_fg_color": "#bbf1dd",
-        "shade_color": "rgba(187, 241, 221, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
         "scrollbar_outline_color": "rgba(21, 28, 25, 0.5)"
     },
     "palette": {

--- a/curated/zorin-os-16-green.json
+++ b/curated/zorin-os-16-green.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#19483e",
         "popover_bg_color": "#ffffff",
         "popover_fg_color": "#19483e",
-        "shade_color": "rgba(25, 72, 62, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.07)",
         "scrollbar_outline_color": "#ffffff"
     },
     "palette": {

--- a/curated/zorin-os-16-grey-dark.json
+++ b/curated/zorin-os-16-grey-dark.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#ffffff",
         "popover_bg_color": "#191919",
         "popover_fg_color": "#ffffff",
-        "shade_color": "rgba(255, 255, 255, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
         "scrollbar_outline_color": "rgba(25, 25, 25, 0.5)"
     },
     "palette": {

--- a/curated/zorin-os-16-grey.json
+++ b/curated/zorin-os-16-grey.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#292929",
         "popover_bg_color": "#ffffff",
         "popover_fg_color": "#292929",
-        "shade_color": "rgba(41, 41, 41, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.07)",
         "scrollbar_outline_color": "#ffffff"
     },
     "palette": {

--- a/curated/zorin-os-16-orange-dark.json
+++ b/curated/zorin-os-16-orange-dark.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#fcc8b4",
         "popover_bg_color": "#1e1715",
         "popover_fg_color": "#fcc8b4",
-        "shade_color": "rgba(252, 200, 180, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
         "scrollbar_outline_color": "rgba(30, 23, 21, 0.5)"
     },
     "palette": {

--- a/curated/zorin-os-16-orange.json
+++ b/curated/zorin-os-16-orange.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#563b25",
         "popover_bg_color": "#ffffff",
         "popover_fg_color": "#563b25",
-        "shade_color": "rgba(86, 59, 37, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.07)",
         "scrollbar_outline_color": "#ffffff"
     },
     "palette": {

--- a/curated/zorin-os-16-purple-dark.json
+++ b/curated/zorin-os-16-purple-dark.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#d8c4f1",
         "popover_bg_color": "#1a181e",
         "popover_fg_color": "#d8c4f1",
-        "shade_color": "rgba(216, 196, 241, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
         "scrollbar_outline_color": "rgba(26, 24, 30, 0.5)"
     },
     "palette": {

--- a/curated/zorin-os-16-purple.json
+++ b/curated/zorin-os-16-purple.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#402b4d",
         "popover_bg_color": "#ffffff",
         "popover_fg_color": "#402b4d",
-        "shade_color": "rgba(64, 43, 77, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.07)",
         "scrollbar_outline_color": "#ffffff"
     },
     "palette": {

--- a/curated/zorin-os-16-red-dark.json
+++ b/curated/zorin-os-16-red-dark.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#fdb4b4",
         "popover_bg_color": "#1e1515",
         "popover_fg_color": "#fdb4b4",
-        "shade_color": "rgba(253, 180, 180, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
         "scrollbar_outline_color": "rgba(30, 21, 21, 0.5)"
     },
     "palette": {

--- a/curated/zorin-os-16-red.json
+++ b/curated/zorin-os-16-red.json
@@ -32,7 +32,7 @@
         "dialog_fg_color": "#572920",
         "popover_bg_color": "#ffffff",
         "popover_fg_color": "#572920",
-        "shade_color": "rgba(87, 41, 32, 0.09)",
+        "shade_color": "rgba(0, 0, 0, 0.07)",
         "scrollbar_outline_color": "#ffffff"
     },
     "palette": {


### PR DESCRIPTION
Initially I didn't realise where this colour was used, but now I know I reverted it back to Adwaita's values, which appears to be very similar to how shadows look in Zorin OS 16

# Checklist 

Before submitting the PR, I checked:

- [x] I've only modified one preset
- [ ] I've added the URL to my raw preset in `presets.json`
- [x] I've checked the format of each json files I modified
- [ ] (optional) I've added screenshots
- [x] The preset name is following preset naming guidelines.

## Publication 

- [x] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
