### PR TITLE
Remove an unnecessary line in the checklist in pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,6 @@
 Before submitting the PR, I checked:
 
 - [ ] I've only modified one preset
-- [ ] I've added the URL to my raw preset in `presets.json`
 - [ ] I've checked the format of each json files I modified
 - [ ] (optional) I've added screenshots
 - [ ] The preset name is following preset naming guidelines.


### PR DESCRIPTION
As Daudix told me on Discord, adding the URL in `presets.json` isn't needed anymore.

# New Preset: <NAME>

<!-- comments -->

## Description

<!-- will be used in the preset list -->

## Palette
  
<!-- a color palette used for this preset -->

- [ ] None
  
## Screenshots (optional)

<!-- Will be used in showcase -->

## Wallpaper

<!-- When we are taking screenshots for adding in the preset list on the website, we can use your background. Maybe add a related background here or nothing if it's not important so we are going to use the default background -->

# Checklist 

Before submitting the PR, I checked:

- [ ] I've only modified one preset
- [ ] I've added the URL to my raw preset in `presets.json` - the whole point of this PR is to remove this line
- [ ] I've checked the format of each json files I modified
- [ ] (optional) I've added screenshots
- [ ] The preset name is following preset naming guidelines.

## Publication 

- [ ] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
