### PR TITLE
Added otto theme

### DIFF
--- a/curated/otto.json
+++ b/curated/otto.json
@@ -1,0 +1,108 @@
+{
+    "name": "otto",
+    "variables": {
+        "accent_color": "#f67066",
+        "accent_bg_color": "#f67066",
+        "accent_fg_color": "#ffffff",
+        "destructive_color": "#da4453",
+        "destructive_bg_color": "#da4453",
+        "destructive_fg_color": "#ffffff",
+        "success_color": "#27ae60",
+        "success_bg_color": "#27ae60",
+        "success_fg_color": "#ffffff",
+        "warning_color": "#f67400",
+        "warning_bg_color": "#f67400",
+        "warning_fg_color": "#ffffff",
+        "error_color": "#da4453",
+        "error_bg_color": "#da4453",
+        "error_fg_color": "#ffffff",
+        "window_bg_color": "#2d3747",
+        "window_fg_color": "#fcfcfc",
+        "view_bg_color": "#2d3747",
+        "view_fg_color": "#fcfcfc",
+        "headerbar_bg_color": "#2d3747",
+        "headerbar_fg_color": "#fcfcfc",
+        "headerbar_border_color": "#fcfcfc",
+        "headerbar_backdrop_color": "#2d3747",
+        "headerbar_shade_color": "rgba(255, 255, 255, 0.09)",
+        "card_bg_color": "#3b4655",
+        "card_fg_color": "#fcfcfc",
+        "card_shade_color": "rgba(255, 255, 255, 0.09)",
+        "dialog_bg_color": "#2d3747",
+        "dialog_fg_color": "#fcfcfc",
+        "popover_bg_color": "#2d3747",
+        "popover_fg_color": "#fcfcfc",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
+        "scrollbar_outline_color": "rgba(0, 0, 0, 0.5)"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    },
+    "plugins": {}
+}


### PR DESCRIPTION
# New Preset: Otto

## Description

Dark theme, with orange and yellow gradient tones.

## Palette
  
https://gitlab.com/jomada/otto
  
## Screenshots (optional)

![Screenshot_20240204_234134](https://github.com/GradienceTeam/Community/assets/36843745/ec01599f-7346-4c49-b2a1-5d35cdeec2b0)

## Wallpaper

![3840x2160](https://github.com/GradienceTeam/Community/assets/36843745/e177c0b9-4f6b-4200-8e93-4e93a5352c61)

# Checklist 

Before submitting the PR, I checked:

- [x] I've only modified one preset
- [x] I've checked the format of each json files I modified
- [x] (optional) I've added screenshots
- [x] The preset name is following preset naming guidelines.

## Publication 

- [x] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
