### PR TITLE
Fix Alpha color themes

### DIFF
--- a/curated/alpha-black.json
+++ b/curated/alpha-black.json
@@ -1,108 +1,108 @@
 {
-    "name": "Alpha Black",
-    "variables": {
-        "accent_color": "#1161cb",
-        "accent_bg_color": "@accent_color",
-        "accent_fg_color": "#ffffff",
-        "destructive_color": "#ff7b63",
-        "destructive_bg_color": "#c01c28",
-        "destructive_fg_color": "#ffffff",
-        "success_color": "#8ff0a4",
-        "success_bg_color": "#26a269",
-        "success_fg_color": "#ffffff",
-        "warning_color": "#f8e45c",
-        "warning_bg_color": "#cd9309",
-        "warning_fg_color": "rgba(0, 0, 0, 0.8)",
-        "error_color": "#ff7b63",
-        "error_bg_color": "#c01c28",
-        "error_fg_color": "#ffffff",
-        "window_bg_color": "#000000",
-        "window_fg_color": "#f8f8f2",
-        "view_bg_color": "#000000",
-        "view_fg_color": "@window_fg_color",
-        "headerbar_bg_color": "@window_bg_color",
-        "headerbar_fg_color": "@window_fg_color",
-        "headerbar_border_color": "#ffffff",
-        "headerbar_backdrop_color": "@window_bg_color",
-        "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
-        "card_bg_color": "rgba(255, 255, 255, 0.05)",
-        "card_fg_color": "@window_fg_color",
-        "card_shade_color": "rgba(0, 0, 0, 0.36)",
-        "dialog_bg_color": "@popover_bg_color",
-        "dialog_fg_color": "@popover_fg_color",
-        "popover_bg_color": "#101010",
-        "popover_fg_color": "@view_fg_color",
-        "shade_color": "rgba(0,0,0,0.36)",
-        "scrollbar_outline_color": "rgba(0,0,0,0.5)"
+  "name": "Alpha Black",
+  "variables": {
+    "accent_color": "#1161cb",
+    "accent_bg_color": "#1161cb",
+    "accent_fg_color": "#ffffff",
+    "destructive_color": "#ff7b63",
+    "destructive_bg_color": "#c01c28",
+    "destructive_fg_color": "#ffffff",
+    "success_color": "#8ff0a4",
+    "success_bg_color": "#26a269",
+    "success_fg_color": "#ffffff",
+    "warning_color": "#f8e45c",
+    "warning_bg_color": "#cd9309",
+    "warning_fg_color": "rgba(0, 0, 0, 0.8)",
+    "error_color": "#ff7b63",
+    "error_bg_color": "#c01c28",
+    "error_fg_color": "#ffffff",
+    "window_bg_color": "#000000",
+    "window_fg_color": "#f8f8f2",
+    "view_bg_color": "#000000",
+    "view_fg_color": "#f8f8f2",
+    "headerbar_bg_color": "#000000",
+    "headerbar_fg_color": "#f8f8f2",
+    "headerbar_border_color": "#ffffff",
+    "headerbar_backdrop_color": "#000000",
+    "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
+    "card_bg_color": "rgba(255, 255, 255, 0.05)",
+    "card_fg_color": "#f8f8f2",
+    "card_shade_color": "rgba(0, 0, 0, 0.36)",
+    "dialog_bg_color": "#101010",
+    "dialog_fg_color": "#f8f8f2",
+    "popover_bg_color": "#101010",
+    "popover_fg_color": "#f8f8f2",
+    "shade_color": "rgba(0,0,0,0.36)",
+    "scrollbar_outline_color": "rgba(0,0,0,0.5)"
+  },
+  "palette": {
+    "blue_": {
+      "1": "#99c1f1",
+      "2": "#62a0ea",
+      "3": "#3584e4",
+      "4": "#1c71d8",
+      "5": "#1a5fb4"
     },
-    "palette": {
-        "blue_": {
-            "1": "#99c1f1",
-            "2": "#62a0ea",
-            "3": "#3584e4",
-            "4": "#1c71d8",
-            "5": "#1a5fb4"
-        },
-        "green_": {
-            "1": "#8ff0a4",
-            "2": "#57e389",
-            "3": "#33d17a",
-            "4": "#2ec27e",
-            "5": "#26a269"
-        },
-        "yellow_": {
-            "1": "#f9f06b",
-            "2": "#f8e45c",
-            "3": "#f6d32d",
-            "4": "#f5c211",
-            "5": "#e5a50a"
-        },
-        "orange_": {
-            "1": "#ffbe6f",
-            "2": "#ffa348",
-            "3": "#ff7800",
-            "4": "#e66100",
-            "5": "#c64600"
-        },
-        "red_": {
-            "1": "#f66151",
-            "2": "#ed333b",
-            "3": "#e01b24",
-            "4": "#c01c28",
-            "5": "#a51d2d"
-        },
-        "purple_": {
-            "1": "#dc8add",
-            "2": "#c061cb",
-            "3": "#9141ac",
-            "4": "#813d9c",
-            "5": "#613583"
-        },
-        "brown_": {
-            "1": "#cdab8f",
-            "2": "#b5835a",
-            "3": "#986a44",
-            "4": "#865e3c",
-            "5": "#63452c"
-        },
-        "light_": {
-            "1": "#ffffff",
-            "2": "#f6f5f4",
-            "3": "#deddda",
-            "4": "#c0bfbc",
-            "5": "#9a9996"
-        },
-        "dark_": {
-            "1": "#77767b",
-            "2": "#5e5c64",
-            "3": "#3d3846",
-            "4": "#241f31",
-            "5": "#000000"
-        }
+    "green_": {
+      "1": "#8ff0a4",
+      "2": "#57e389",
+      "3": "#33d17a",
+      "4": "#2ec27e",
+      "5": "#26a269"
     },
-    "custom_css": {
-        "gtk4": "/* GTK4 */\n\nwindowcontrols > button {\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n}\n\nwindowcontrols > button > image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nwindowcontrols > button.close {\n  background-color: #505050;\n}\n\nbutton.titlebutton.close:hover,\nwindowcontrols > button.close:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.maximize,\nwindowcontrols > button.maximize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.maximize:hover,\nwindowcontrols > button.maximize:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.minimize,\nwindowcontrols > button.minimize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.minimize:hover,\nwindowcontrols > button.minimize:hover {\n  opacity: 0.8;\n}",
-        "gtk3": "/* GTK3 */\n\nbutton.titlebutton {\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n  background-color: #505050;\n  border: none;\n}\n\nbutton.titlebutton:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nbutton.titlebutton.maximize,\nbutton.titlebutton.minimize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.close:hover,\nbutton.titlebutton.maximize:hover,\nbutton.titlebutton.minimize:hover {\n  opacity: 0.8;\n}\n"
+    "yellow_": {
+      "1": "#f9f06b",
+      "2": "#f8e45c",
+      "3": "#f6d32d",
+      "4": "#f5c211",
+      "5": "#e5a50a"
     },
-    "plugins": {}
+    "orange_": {
+      "1": "#ffbe6f",
+      "2": "#ffa348",
+      "3": "#ff7800",
+      "4": "#e66100",
+      "5": "#c64600"
+    },
+    "red_": {
+      "1": "#f66151",
+      "2": "#ed333b",
+      "3": "#e01b24",
+      "4": "#c01c28",
+      "5": "#a51d2d"
+    },
+    "purple_": {
+      "1": "#dc8add",
+      "2": "#c061cb",
+      "3": "#9141ac",
+      "4": "#813d9c",
+      "5": "#613583"
+    },
+    "brown_": {
+      "1": "#cdab8f",
+      "2": "#b5835a",
+      "3": "#986a44",
+      "4": "#865e3c",
+      "5": "#63452c"
+    },
+    "light_": {
+      "1": "#ffffff",
+      "2": "#f6f5f4",
+      "3": "#deddda",
+      "4": "#c0bfbc",
+      "5": "#9a9996"
+    },
+    "dark_": {
+      "1": "#77767b",
+      "2": "#5e5c64",
+      "3": "#3d3846",
+      "4": "#241f31",
+      "5": "#000000"
+    }
+  },
+  "custom_css": {
+    "gtk4": "/* GTK4 */\n\nwindowcontrols > button {\n min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n}\n\nwindowcontrols > button > image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nwindowcontrols > button.close {\n  background-color: #505050;\n}\n\nbutton.titlebutton.close:hover,\nwindowcontrols > button.close:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.maximize,\nwindowcontrols > button.maximize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.maximize:hover,\nwindowcontrols > button.maximize:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.minimize,\nwindowcontrols > button.minimize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.minimize:hover,\nwindowcontrols > button.minimize:hover {\n  opacity: 0.8;\n}",
+    "gtk3": "/* GTK3 */\n\nbutton.titlebutton {\n min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n  background-color: #505050;\n  border: none;\n}\n\nbutton.titlebutton:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nbutton.titlebutton.maximize,\nbutton.titlebutton.minimize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.close:hover,\nbutton.titlebutton.maximize:hover,\nbutton.titlebutton.minimize:hover {\n  opacity: 0.8;\n}\n"
+  },
+  "plugins": {}
 }

--- a/curated/alpha-dark.json
+++ b/curated/alpha-dark.json
@@ -1,108 +1,108 @@
 {
-    "name": "Alpha Dark",
-    "variables": {
-        "accent_color": "@accent_bg_color",
-        "accent_bg_color": "#1161cb",
-        "accent_fg_color": "#ffffff",
-        "destructive_color": "#ff7b63",
-        "destructive_bg_color": "#c01c28",
-        "destructive_fg_color": "#ffffff",
-        "success_color": "#8ff0a4",
-        "success_bg_color": "#26a269",
-        "success_fg_color": "#ffffff",
-        "warning_color": "#f8e45c",
-        "warning_bg_color": "#cd9309",
-        "warning_fg_color": "rgba(0, 0, 0, 0.8)",
-        "error_color": "#ff7b63",
-        "error_bg_color": "#c01c28",
-        "error_fg_color": "#ffffff",
-        "window_bg_color": "#101010",
-        "window_fg_color": "#f8f8f2",
-        "view_bg_color": "#101010",
-        "view_fg_color": "@window_fg_color",
-        "headerbar_bg_color": "@window_bg_color",
-        "headerbar_fg_color": "@window_fg_color",
-        "headerbar_border_color": "#ffffff",
-        "headerbar_backdrop_color": "@window_bg_color",
-        "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
-        "card_bg_color": "rgba(255, 255, 255, 0.08)",
-        "card_fg_color": "@window_fg_color",
-        "card_shade_color": "rgba(0, 0, 0, 0.36)",
-        "dialog_bg_color": "@popover_bg_color",
-        "dialog_fg_color": "@popover_fg_color",
-        "popover_bg_color": "#202020",
-        "popover_fg_color": "@view_fg_color",
-        "shade_color": "rgba(0,0,0,0.36)",
-        "scrollbar_outline_color": "rgba(0,0,0,0.5)"
+  "name": "Alpha Dark",
+  "variables": {
+    "accent_color": "#1161cb",
+    "accent_bg_color": "#1161cb",
+    "accent_fg_color": "#ffffff",
+    "destructive_color": "#ff7b63",
+    "destructive_bg_color": "#c01c28",
+    "destructive_fg_color": "#ffffff",
+    "success_color": "#8ff0a4",
+    "success_bg_color": "#26a269",
+    "success_fg_color": "#ffffff",
+    "warning_color": "#f8e45c",
+    "warning_bg_color": "#cd9309",
+    "warning_fg_color": "rgba(0, 0, 0, 0.8)",
+    "error_color": "#ff7b63",
+    "error_bg_color": "#c01c28",
+    "error_fg_color": "#ffffff",
+    "window_bg_color": "#101010",
+    "window_fg_color": "#f8f8f2",
+    "view_bg_color": "#101010",
+    "view_fg_color": "#f8f8f2",
+    "headerbar_bg_color": "#101010",
+    "headerbar_fg_color": "#f8f8f2",
+    "headerbar_border_color": "#ffffff",
+    "headerbar_backdrop_color": "#101010",
+    "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
+    "card_bg_color": "rgba(255, 255, 255, 0.08)",
+    "card_fg_color": "#f8f8f2",
+    "card_shade_color": "rgba(0, 0, 0, 0.36)",
+    "dialog_bg_color": "#202020",
+    "dialog_fg_color": "#f8f8f2",
+    "popover_bg_color": "#202020",
+    "popover_fg_color": "#f8f8f2",
+    "shade_color": "rgba(0,0,0,0.36)",
+    "scrollbar_outline_color": "rgba(0,0,0,0.5)"
+  },
+  "palette": {
+    "blue_": {
+      "1": "#99c1f1",
+      "2": "#62a0ea",
+      "3": "#3584e4",
+      "4": "#1c71d8",
+      "5": "#1a5fb4"
     },
-    "palette": {
-        "blue_": {
-            "1": "#99c1f1",
-            "2": "#62a0ea",
-            "3": "#3584e4",
-            "4": "#1c71d8",
-            "5": "#1a5fb4"
-        },
-        "green_": {
-            "1": "#8ff0a4",
-            "2": "#57e389",
-            "3": "#33d17a",
-            "4": "#2ec27e",
-            "5": "#26a269"
-        },
-        "yellow_": {
-            "1": "#f9f06b",
-            "2": "#f8e45c",
-            "3": "#f6d32d",
-            "4": "#f5c211",
-            "5": "#e5a50a"
-        },
-        "orange_": {
-            "1": "#ffbe6f",
-            "2": "#ffa348",
-            "3": "#ff7800",
-            "4": "#e66100",
-            "5": "#c64600"
-        },
-        "red_": {
-            "1": "#f66151",
-            "2": "#ed333b",
-            "3": "#e01b24",
-            "4": "#c01c28",
-            "5": "#a51d2d"
-        },
-        "purple_": {
-            "1": "#dc8add",
-            "2": "#c061cb",
-            "3": "#9141ac",
-            "4": "#813d9c",
-            "5": "#613583"
-        },
-        "brown_": {
-            "1": "#cdab8f",
-            "2": "#b5835a",
-            "3": "#986a44",
-            "4": "#865e3c",
-            "5": "#63452c"
-        },
-        "light_": {
-            "1": "#ffffff",
-            "2": "#f6f5f4",
-            "3": "#deddda",
-            "4": "#c0bfbc",
-            "5": "#9a9996"
-        },
-        "dark_": {
-            "1": "#77767b",
-            "2": "#5e5c64",
-            "3": "#3d3846",
-            "4": "#241f31",
-            "5": "#000000"
-        }
+    "green_": {
+      "1": "#8ff0a4",
+      "2": "#57e389",
+      "3": "#33d17a",
+      "4": "#2ec27e",
+      "5": "#26a269"
     },
-    "custom_css": {
-        "gtk4": "/* GTK4 */\n\nwindowcontrols > button { /* GTK4 */\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n}\n\nwindowcontrols > button > image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nwindowcontrols > button.close {\n  background-color: #505050;\n}\n\nbutton.titlebutton.close:hover,\nwindowcontrols > button.close:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.maximize,\nwindowcontrols > button.maximize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.maximize:hover,\nwindowcontrols > button.maximize:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.minimize,\nwindowcontrols > button.minimize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.minimize:hover,\nwindowcontrols > button.minimize:hover {\n  opacity: 0.8;\n}",
-        "gtk3": "/* GTK3 */\n\nbutton.titlebutton {\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n  background-color: #505050;\n  border: none;\n}\n\nbutton.titlebutton:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nbutton.titlebutton.maximize,\nbutton.titlebutton.minimize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.close:hover,\nbutton.titlebutton.maximize:hover,\nbutton.titlebutton.minimize:hover {\n  opacity: 0.8;\n}\n"
+    "yellow_": {
+      "1": "#f9f06b",
+      "2": "#f8e45c",
+      "3": "#f6d32d",
+      "4": "#f5c211",
+      "5": "#e5a50a"
     },
-    "plugins": {}
+    "orange_": {
+      "1": "#ffbe6f",
+      "2": "#ffa348",
+      "3": "#ff7800",
+      "4": "#e66100",
+      "5": "#c64600"
+    },
+    "red_": {
+      "1": "#f66151",
+      "2": "#ed333b",
+      "3": "#e01b24",
+      "4": "#c01c28",
+      "5": "#a51d2d"
+    },
+    "purple_": {
+      "1": "#dc8add",
+      "2": "#c061cb",
+      "3": "#9141ac",
+      "4": "#813d9c",
+      "5": "#613583"
+    },
+    "brown_": {
+      "1": "#cdab8f",
+      "2": "#b5835a",
+      "3": "#986a44",
+      "4": "#865e3c",
+      "5": "#63452c"
+    },
+    "light_": {
+      "1": "#ffffff",
+      "2": "#f6f5f4",
+      "3": "#deddda",
+      "4": "#c0bfbc",
+      "5": "#9a9996"
+    },
+    "dark_": {
+      "1": "#77767b",
+      "2": "#5e5c64",
+      "3": "#3d3846",
+      "4": "#241f31",
+      "5": "#000000"
+    }
+  },
+  "custom_css": {
+    "gtk4": "/* GTK4 */\n\nwindowcontrols > button { /* GTK4 */\n min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n}\n\nwindowcontrols > button > image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nwindowcontrols > button.close {\n  background-color: #505050;\n}\n\nbutton.titlebutton.close:hover,\nwindowcontrols > button.close:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.maximize,\nwindowcontrols > button.maximize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.maximize:hover,\nwindowcontrols > button.maximize:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.minimize,\nwindowcontrols > button.minimize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.minimize:hover,\nwindowcontrols > button.minimize:hover {\n  opacity: 0.8;\n}",
+    "gtk3": "/* GTK3 */\n\nbutton.titlebutton {\n min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n  background-color: #505050;\n  border: none;\n}\n\nbutton.titlebutton:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nbutton.titlebutton.maximize,\nbutton.titlebutton.minimize {\n  background-color: #505050;\n}\n\nbutton.titlebutton.close:hover,\nbutton.titlebutton.maximize:hover,\nbutton.titlebutton.minimize:hover {\n  opacity: 0.8;\n}\n"
+  },
+  "plugins": {}
 }

--- a/curated/alpha-mac.json
+++ b/curated/alpha-mac.json
@@ -1,108 +1,108 @@
 {
-    "name": "Alpha Mac",
-    "variables": {
-        "accent_color": "@accent_bg_color",
-        "accent_bg_color": "rgb(17,97,203)",
-        "accent_fg_color": "#ffffff",
-        "destructive_color": "#ff7b63",
-        "destructive_bg_color": "#c01c28",
-        "destructive_fg_color": "#ffffff",
-        "success_color": "#8ff0a4",
-        "success_bg_color": "#26a269",
-        "success_fg_color": "#ffffff",
-        "warning_color": "#f8e45c",
-        "warning_bg_color": "#cd9309",
-        "warning_fg_color": "rgba(0, 0, 0, 0.8)",
-        "error_color": "#ff7b63",
-        "error_bg_color": "#c01c28",
-        "error_fg_color": "#ffffff",
-        "window_bg_color": "rgb(16,16,16)",
-        "window_fg_color": "rgb(248,248,242)",
-        "view_bg_color": "rgb(16,16,16)",
-        "view_fg_color": "@window_fg_color",
-        "headerbar_bg_color": "@window_bg_color",
-        "headerbar_fg_color": "@window_fg_color",
-        "headerbar_border_color": "#ffffff",
-        "headerbar_backdrop_color": "@window_bg_color",
-        "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
-        "card_bg_color": "rgba(255, 255, 255, 0.08)",
-        "card_fg_color": " @window_fg_color",
-        "card_shade_color": "rgba(0, 0, 0, 0.36)",
-        "dialog_bg_color": "@popover_bg_color",
-        "dialog_fg_color": "@popover_fg_color",
-        "popover_bg_color": "#202020",
-        "popover_fg_color": "@view_fg_color",
-        "shade_color": "rgba(0,0,0,0.36)",
-        "scrollbar_outline_color": "rgba(0,0,0,0.5)"
+  "name": "Alpha Mac",
+  "variables": {
+    "accent_color": "rgb(17,97,203)",
+    "accent_bg_color": "rgb(17,97,203)",
+    "accent_fg_color": "#ffffff",
+    "destructive_color": "#ff7b63",
+    "destructive_bg_color": "#c01c28",
+    "destructive_fg_color": "#ffffff",
+    "success_color": "#8ff0a4",
+    "success_bg_color": "#26a269",
+    "success_fg_color": "#ffffff",
+    "warning_color": "#f8e45c",
+    "warning_bg_color": "#cd9309",
+    "warning_fg_color": "rgba(0, 0, 0, 0.8)",
+    "error_color": "#ff7b63",
+    "error_bg_color": "#c01c28",
+    "error_fg_color": "#ffffff",
+    "window_bg_color": "rgb(16,16,16)",
+    "window_fg_color": "rgb(248,248,242)",
+    "view_bg_color": "rgb(16,16,16)",
+    "view_fg_color": "rgb(248,248,242)",
+    "headerbar_bg_color": "rgb(16,16,16)",
+    "headerbar_fg_color": "rgb(248,248,242)",
+    "headerbar_border_color": "#ffffff",
+    "headerbar_backdrop_color": "rgb(16,16,16)",
+    "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
+    "card_bg_color": "rgba(255, 255, 255, 0.08)",
+    "card_fg_color": " rgb(248,248,242)",
+    "card_shade_color": "rgba(0, 0, 0, 0.36)",
+    "dialog_bg_color": "#202020",
+    "dialog_fg_color": "rgb(248,248,242)r",
+    "popover_bg_color": "#202020",
+    "popover_fg_color": "rgb(248,248,242)",
+    "shade_color": "rgba(0,0,0,0.36)",
+    "scrollbar_outline_color": "rgba(0,0,0,0.5)"
+  },
+  "palette": {
+    "blue_": {
+      "1": "#99c1f1",
+      "2": "#62a0ea",
+      "3": "#3584e4",
+      "4": "#1c71d8",
+      "5": "#1a5fb4"
     },
-    "palette": {
-        "blue_": {
-            "1": "#99c1f1",
-            "2": "#62a0ea",
-            "3": "#3584e4",
-            "4": "#1c71d8",
-            "5": "#1a5fb4"
-        },
-        "green_": {
-            "1": "#8ff0a4",
-            "2": "#57e389",
-            "3": "#33d17a",
-            "4": "#2ec27e",
-            "5": "#26a269"
-        },
-        "yellow_": {
-            "1": "#f9f06b",
-            "2": "#f8e45c",
-            "3": "#f6d32d",
-            "4": "#f5c211",
-            "5": "#e5a50a"
-        },
-        "orange_": {
-            "1": "#ffbe6f",
-            "2": "#ffa348",
-            "3": "#ff7800",
-            "4": "#e66100",
-            "5": "#c64600"
-        },
-        "red_": {
-            "1": "#f66151",
-            "2": "#ed333b",
-            "3": "#e01b24",
-            "4": "#c01c28",
-            "5": "#a51d2d"
-        },
-        "purple_": {
-            "1": "#dc8add",
-            "2": "#c061cb",
-            "3": "#9141ac",
-            "4": "#813d9c",
-            "5": "#613583"
-        },
-        "brown_": {
-            "1": "#cdab8f",
-            "2": "#b5835a",
-            "3": "#986a44",
-            "4": "#865e3c",
-            "5": "#63452c"
-        },
-        "light_": {
-            "1": "#ffffff",
-            "2": "#f6f5f4",
-            "3": "#deddda",
-            "4": "#c0bfbc",
-            "5": "#9a9996"
-        },
-        "dark_": {
-            "1": "#77767b",
-            "2": "#5e5c64",
-            "3": "#3d3846",
-            "4": "#241f31",
-            "5": "#000000"
-        }
+    "green_": {
+      "1": "#8ff0a4",
+      "2": "#57e389",
+      "3": "#33d17a",
+      "4": "#2ec27e",
+      "5": "#26a269"
     },
-    "custom_css": {
-        "gtk4": "/* GTK4 */\n\nwindowcontrols > button {\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n}\n\nwindowcontrols > button > image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nwindowcontrols > button.close {\n  background-color: #fc5753;\n  border: 1px solid #e04644;\n}\n\nbutton.titlebutton.close:hover,\nwindowcontrols > button.close:hover {\n  color: #7e0608;\n  opacity: 0.8;\n}\n\nbutton.titlebutton.maximize,\nwindowcontrols > button.maximize {\n  background-color: #33c848;\n  border: 1px solid #3e9948;\n}\n\nbutton.titlebutton.maximize:hover,\nwindowcontrols > button.maximize:hover {\n  color: #0b650d;\n  opacity: 0.8;\n}\n\nbutton.titlebutton.minimize,\nwindowcontrols > button.minimize {\n  background-color: #ffba40;\n  border: 1px solid #dd9d30;\n}\n\nbutton.titlebutton.minimize:hover,\nwindowcontrols > button.minimize:hover {\n  color: #9a5711;\n  opacity: 0.8;\n}\n",
-        "gtk3": "/* GTK3 */\n\nbutton.titlebutton {\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n  background-color: transparent;\n  border: none;\n}\n\nbutton.titlebutton:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nbutton.titlebutton.maximize,\nbutton.titlebutton.minimize {\n  background-color: transparent;\n  border: 1px solid transparent;\n}\n\nbutton.titlebutton.close:hover,\nbutton.titlebutton.maximize:hover,\nbutton.titlebutton.minimize:hover {\n  color: transparent;\n  opacity: 0.8;\n}\n\nbutton.titlebutton.close {\n  background-color: #fc5753;\n  border-color: #e04644;\n}\n\nbutton.titlebutton.close:hover {\n  color: #7e0608;\n}\n\nbutton.titlebutton.maximize {\n  background-color: #33c848;\n  border-color: #3e9948;\n}\n\nbutton.titlebutton.maximize:hover {\n  color: #0b650d;\n}\n\nbutton.titlebutton.minimize {\n  background-color: #ffba40;\n  border-color: #dd9d30;\n}\n\nbutton.titlebutton.minimize:hover {\n  color: #9a5711;\n}\n"
+    "yellow_": {
+      "1": "#f9f06b",
+      "2": "#f8e45c",
+      "3": "#f6d32d",
+      "4": "#f5c211",
+      "5": "#e5a50a"
     },
-    "plugins": {}
+    "orange_": {
+      "1": "#ffbe6f",
+      "2": "#ffa348",
+      "3": "#ff7800",
+      "4": "#e66100",
+      "5": "#c64600"
+    },
+    "red_": {
+      "1": "#f66151",
+      "2": "#ed333b",
+      "3": "#e01b24",
+      "4": "#c01c28",
+      "5": "#a51d2d"
+    },
+    "purple_": {
+      "1": "#dc8add",
+      "2": "#c061cb",
+      "3": "#9141ac",
+      "4": "#813d9c",
+      "5": "#613583"
+    },
+    "brown_": {
+      "1": "#cdab8f",
+      "2": "#b5835a",
+      "3": "#986a44",
+      "4": "#865e3c",
+      "5": "#63452c"
+    },
+    "light_": {
+      "1": "#ffffff",
+      "2": "#f6f5f4",
+      "3": "#deddda",
+      "4": "#c0bfbc",
+      "5": "#9a9996"
+    },
+    "dark_": {
+      "1": "#77767b",
+      "2": "#5e5c64",
+      "3": "#3d3846",
+      "4": "#241f31",
+      "5": "#000000"
+    }
+  },
+  "custom_css": {
+    "gtk4": "/* GTK4 */\n\nwindowcontrols > button {\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n}\n\nwindowcontrols > button > image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nwindowcontrols > button.close {\n  background-color: #fc5753;\n  border: 1px solid #e04644;\n}\n\nbutton.titlebutton.close:hover,\nwindowcontrols > button.close:hover {\n  color: #7e0608;\n  opacity: 0.8;\n}\n\nbutton.titlebutton.maximize,\nwindowcontrols > button.maximize {\n  background-color: #33c848;\n  border: 1px solid #3e9948;\n}\n\nbutton.titlebutton.maximize:hover,\nwindowcontrols > button.maximize:hover {\n  color: #0b650d;\n  opacity: 0.8;\n}\n\nbutton.titlebutton.minimize,\nwindowcontrols > button.minimize {\n  background-color: #ffba40;\n  border: 1px solid #dd9d30;\n}\n\nbutton.titlebutton.minimize:hover,\nwindowcontrols > button.minimize:hover {\n  color: #9a5711;\n  opacity: 0.8;\n}\n",
+    "gtk3": "/* GTK3 */\n\nbutton.titlebutton {\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n  background-color: transparent;\n  border: none;\n}\n\nbutton.titlebutton:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nbutton.titlebutton.maximize,\nbutton.titlebutton.minimize {\n  background-color: transparent;\n  border: 1px solid transparent;\n}\n\nbutton.titlebutton.close:hover,\nbutton.titlebutton.maximize:hover,\nbutton.titlebutton.minimize:hover {\n  color: transparent;\n  opacity: 0.8;\n}\n\nbutton.titlebutton.close {\n  background-color: #fc5753;\n  border-color: #e04644;\n}\n\nbutton.titlebutton.close:hover {\n  color: #7e0608;\n}\n\nbutton.titlebutton.maximize {\n  background-color: #33c848;\n  border-color: #3e9948;\n}\n\nbutton.titlebutton.maximize:hover {\n  color: #0b650d;\n}\n\nbutton.titlebutton.minimize {\n  background-color: #ffba40;\n  border-color: #dd9d30;\n}\n\nbutton.titlebutton.minimize:hover {\n  color: #9a5711;\n}\n"
+  },
+  "plugins": {}
 }

--- a/curated/alpha-tritanopia.json
+++ b/curated/alpha-tritanopia.json
@@ -1,108 +1,108 @@
 {
-    "name": "Alpha Tritanopia",
-    "variables": {
-        "accent_color": "rgb(31,111,235)",
-        "accent_bg_color": "rgb(31,111,235)",
-        "accent_fg_color": "#ffffff",
-        "destructive_color": "#ff7b63",
-        "destructive_bg_color": "#c01c28",
-        "destructive_fg_color": "#ffffff",
-        "success_color": "#8ff0a4",
-        "success_bg_color": "#26a269",
-        "success_fg_color": "#ffffff",
-        "warning_color": "#f8e45c",
-        "warning_bg_color": "#cd9309",
-        "warning_fg_color": "rgba(0, 0, 0, 0.8)",
-        "error_color": "#ff7b63",
-        "error_bg_color": "#c01c28",
-        "error_fg_color": "#ffffff",
-        "window_bg_color": "rgb(13,17,23)",
-        "window_fg_color": "rgb(248,248,242)",
-        "view_bg_color": "rgb(13,17,23)",
-        "view_fg_color": "rgb(248,248,242)",
-        "headerbar_bg_color": "rgb(13,17,23)",
-        "headerbar_fg_color": "rgb(248,248,242)",
-        "headerbar_border_color": "#ffffff",
-        "headerbar_backdrop_color": "@window_bg_color",
-        "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
-        "card_bg_color": "rgb(22,27,34)",
-        "card_fg_color": "rgb(248,248,242)",
-        "card_shade_color": "rgba(0, 0, 0, 0.36)",
-        "dialog_bg_color": "rgb(22,27,34)",
-        "dialog_fg_color": "rgb(248,248,242)",
-        "popover_bg_color": "rgb(22,27,34)",
-        "popover_fg_color": "rgb(248,248,242)",
-        "shade_color": "rgba(0,0,0,0.36)",
-        "scrollbar_outline_color": "rgba(0,0,0,0.5)"
+  "name": "Alpha Tritanopia",
+  "variables": {
+    "accent_color": "rgb(31,111,235)",
+    "accent_bg_color": "rgb(31,111,235)",
+    "accent_fg_color": "#ffffff",
+    "destructive_color": "#ff7b63",
+    "destructive_bg_color": "#c01c28",
+    "destructive_fg_color": "#ffffff",
+    "success_color": "#8ff0a4",
+    "success_bg_color": "#26a269",
+    "success_fg_color": "#ffffff",
+    "warning_color": "#f8e45c",
+    "warning_bg_color": "#cd9309",
+    "warning_fg_color": "rgba(0, 0, 0, 0.8)",
+    "error_color": "#ff7b63",
+    "error_bg_color": "#c01c28",
+    "error_fg_color": "#ffffff",
+    "window_bg_color": "rgb(13,17,23)",
+    "window_fg_color": "rgb(248,248,242)",
+    "view_bg_color": "rgb(13,17,23)",
+    "view_fg_color": "rgb(248,248,242)",
+    "headerbar_bg_color": "rgb(13,17,23)",
+    "headerbar_fg_color": "rgb(248,248,242)",
+    "headerbar_border_color": "#ffffff",
+    "headerbar_backdrop_color": "rgb(13,17,23)",
+    "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
+    "card_bg_color": "rgb(22,27,34)",
+    "card_fg_color": "rgb(248,248,242)",
+    "card_shade_color": "rgba(0, 0, 0, 0.36)",
+    "dialog_bg_color": "rgb(22,27,34)",
+    "dialog_fg_color": "rgb(248,248,242)",
+    "popover_bg_color": "rgb(22,27,34)",
+    "popover_fg_color": "rgb(248,248,242)",
+    "shade_color": "rgba(0,0,0,0.36)",
+    "scrollbar_outline_color": "rgba(0,0,0,0.5)"
+  },
+  "palette": {
+    "blue_": {
+      "1": "#99c1f1",
+      "2": "#62a0ea",
+      "3": "#3584e4",
+      "4": "#1c71d8",
+      "5": "#1a5fb4"
     },
-    "palette": {
-        "blue_": {
-            "1": "#99c1f1",
-            "2": "#62a0ea",
-            "3": "#3584e4",
-            "4": "#1c71d8",
-            "5": "#1a5fb4"
-        },
-        "green_": {
-            "1": "#8ff0a4",
-            "2": "#57e389",
-            "3": "#33d17a",
-            "4": "#2ec27e",
-            "5": "#26a269"
-        },
-        "yellow_": {
-            "1": "#f9f06b",
-            "2": "#f8e45c",
-            "3": "#f6d32d",
-            "4": "#f5c211",
-            "5": "#e5a50a"
-        },
-        "orange_": {
-            "1": "#ffbe6f",
-            "2": "#ffa348",
-            "3": "#ff7800",
-            "4": "#e66100",
-            "5": "#c64600"
-        },
-        "red_": {
-            "1": "#f66151",
-            "2": "#ed333b",
-            "3": "#e01b24",
-            "4": "#c01c28",
-            "5": "#a51d2d"
-        },
-        "purple_": {
-            "1": "#dc8add",
-            "2": "#c061cb",
-            "3": "#9141ac",
-            "4": "#813d9c",
-            "5": "#613583"
-        },
-        "brown_": {
-            "1": "#cdab8f",
-            "2": "#b5835a",
-            "3": "#986a44",
-            "4": "#865e3c",
-            "5": "#63452c"
-        },
-        "light_": {
-            "1": "#ffffff",
-            "2": "#f6f5f4",
-            "3": "#deddda",
-            "4": "#c0bfbc",
-            "5": "#9a9996"
-        },
-        "dark_": {
-            "1": "#77767b",
-            "2": "#5e5c64",
-            "3": "#3d3846",
-            "4": "#241f31",
-            "5": "#000000"
-        }
+    "green_": {
+      "1": "#8ff0a4",
+      "2": "#57e389",
+      "3": "#33d17a",
+      "4": "#2ec27e",
+      "5": "#26a269"
     },
-    "custom_css": {
-        "gtk4": "/* GTK4 */\n\nwindowcontrols > button {\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n}\n\nwindowcontrols > button > image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nwindowcontrols > button.close {\n  background-color: #474b52;\n}\n\nbutton.titlebutton.close:hover,\nwindowcontrols > button.close:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.maximize,\nwindowcontrols > button.maximize {\n  background-color: #474b52;\n}\n\nbutton.titlebutton.maximize:hover,\nwindowcontrols > button.maximize:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.minimize,\nwindowcontrols > button.minimize {\n  background-color: #474b52;\n}\n\nbutton.titlebutton.minimize:hover,\nwindowcontrols > button.minimize:hover {\n  opacity: 0.8;\n}",
-        "gtk3": "/* GTK3 */\n\nbutton.titlebutton {\n  color: transparent;\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n  background-color: transparent;\n  border: none;\n}\n\nbutton.titlebutton:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nbutton.titlebutton.maximize,\nbutton.titlebutton.minimize {\n  background-color: #474b52;\n  border: none;\n}\n\nbutton.titlebutton.close:hover,\nbutton.titlebutton.maximize:hover,\nbutton.titlebutton.minimize:hover {\n  opacity: 0.8;\n}\n"
+    "yellow_": {
+      "1": "#f9f06b",
+      "2": "#f8e45c",
+      "3": "#f6d32d",
+      "4": "#f5c211",
+      "5": "#e5a50a"
     },
-    "plugins": {}
+    "orange_": {
+      "1": "#ffbe6f",
+      "2": "#ffa348",
+      "3": "#ff7800",
+      "4": "#e66100",
+      "5": "#c64600"
+    },
+    "red_": {
+      "1": "#f66151",
+      "2": "#ed333b",
+      "3": "#e01b24",
+      "4": "#c01c28",
+      "5": "#a51d2d"
+    },
+    "purple_": {
+      "1": "#dc8add",
+      "2": "#c061cb",
+      "3": "#9141ac",
+      "4": "#813d9c",
+      "5": "#613583"
+    },
+    "brown_": {
+      "1": "#cdab8f",
+      "2": "#b5835a",
+      "3": "#986a44",
+      "4": "#865e3c",
+      "5": "#63452c"
+    },
+    "light_": {
+      "1": "#ffffff",
+      "2": "#f6f5f4",
+      "3": "#deddda",
+      "4": "#c0bfbc",
+      "5": "#9a9996"
+    },
+    "dark_": {
+      "1": "#77767b",
+      "2": "#5e5c64",
+      "3": "#3d3846",
+      "4": "#241f31",
+      "5": "#000000"
+    }
+  },
+  "custom_css": {
+    "gtk4": "/* GTK4 */\n\nwindowcontrols > button {\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n}\n\nwindowcontrols > button > image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nwindowcontrols > button.close {\n  background-color: #474b52;\n}\n\nbutton.titlebutton.close:hover,\nwindowcontrols > button.close:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.maximize,\nwindowcontrols > button.maximize {\n  background-color: #474b52;\n}\n\nbutton.titlebutton.maximize:hover,\nwindowcontrols > button.maximize:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton.minimize,\nwindowcontrols > button.minimize {\n  background-color: #474b52;\n}\n\nbutton.titlebutton.minimize:hover,\nwindowcontrols > button.minimize:hover {\n  opacity: 0.8;\n}",
+    "gtk3": "/* GTK3 */\n\nbutton.titlebutton {\n  min-width: 2px;\n  min-height: 2px;\n  border-radius: 100%;\n  padding: 0;\n  margin: 0 5px;\n  background-color: transparent;\n  border: none;\n}\n\nbutton.titlebutton:hover {\n  opacity: 0.8;\n}\n\nbutton.titlebutton image {\n  padding: 0;\n}\n\nbutton.titlebutton.close,\nbutton.titlebutton.maximize,\nbutton.titlebutton.minimize {\n  background-color: #474b52;\n  border: none;\n}\n\nbutton.titlebutton.close:hover,\nbutton.titlebutton.maximize:hover,\nbutton.titlebutton.minimize:hover {\n  opacity: 0.8;\n}\n"
+  },
+  "plugins": {}
 }


### PR DESCRIPTION
## Description

- Fix some color options which previously using placeholder that caused some error on plugin like Firefox Gnome theme (some parts shown as transparent which is hard to read)
- Fix Custom CSS to make symbols on windows manager (close, minimize button) visible (only on Dark, Black and Tritanopia -- the Mac version I think the creator intended to use color as symbolic)
  
## Screenshots (optional)

![Screenshot from 2024-03-26 15-09-47](https://github.com/GradienceTeam/Community/assets/141404845/3a24474b-e3e8-4bb5-80e9-a831edb57b89) ![Screenshot from 2024-03-26 15-10-09](https://github.com/GradienceTeam/Community/assets/141404845/270259aa-31d5-4865-9cc0-6e446ee30bd5)

# Checklist 

Before submitting the PR, I checked:

- [ ] I've only modified one preset
- [x] I've checked the format of each json files I modified
- [x] (optional) I've added screenshots
- [x] The preset name is following preset naming guidelines.

Thanks for your submission we will review and merge it as quick as possible.